### PR TITLE
AttributeError referencing session_id

### DIFF
--- a/ecmcli/commands/shell.py
+++ b/ecmcli/commands/shell.py
@@ -42,7 +42,7 @@ class Shell(base.ECMCommand):
         print("Connecting to: %s (%s)" % (router['name'], router['id']))
         print("Type ~~ rapidly to close session")
         sessionid = int(time.time() * 10000) if args.new else \
-            self.api.session_id
+            self.api.legacy_id
         with self.setup_tty():
             self.rsh(router, sessionid)
 


### PR DESCRIPTION
Perform a 'shell' command to get to a router. Shell throws this error.

Assuming session_id should be legacy_id.

Tested and no longer saw error